### PR TITLE
Save in ICNS format to support all operating systems

### DIFF
--- a/Tests/test_file_icns.py
+++ b/Tests/test_file_icns.py
@@ -1,5 +1,4 @@
 import io
-import sys
 
 import pytest
 from PIL import IcnsImagePlugin, Image
@@ -25,7 +24,6 @@ def test_sanity():
         assert im.format == "ICNS"
 
 
-@pytest.mark.skipif(sys.platform != "darwin", reason="Requires macOS")
 def test_save(tmp_path):
     temp_file = str(tmp_path / "temp.icns")
 
@@ -38,7 +36,6 @@ def test_save(tmp_path):
         assert reread.format == "ICNS"
 
 
-@pytest.mark.skipif(sys.platform != "darwin", reason="Requires macOS")
 def test_save_append_images(tmp_path):
     temp_file = str(tmp_path / "temp.icns")
     provided_im = Image.new("RGBA", (32, 32), (255, 0, 0, 128))

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -19,11 +19,8 @@
 
 import io
 import os
-import shutil
 import struct
-import subprocess
 import sys
-import tempfile
 
 from PIL import Image, ImageFile, PngImagePlugin
 from PIL._binary import i8
@@ -304,13 +301,13 @@ class IcnsImageFile(ImageFile.ImageFile):
 
 
 def to_int(s):
-    b = s.encode('ascii')
+    b = s.encode("ascii")
     return (b[0] << 24) | (b[1] << 16) | (b[2] << 8) | b[3]
 
 
 MAGIC = to_int("icns")
 HEADER_SIZE = 8
-TOC = 'TOC '
+TOC = "TOC "
 
 
 def _save(im, fp, filename):
@@ -325,37 +322,35 @@ def _save(im, fp, filename):
 
     # size
     sizes = [128, 256, 512, 32, 64, 256, 512, 1024]
-    size_str = ['ic07', 'ic08', 'ic09', 'ic11', 'ic12', 'ic13', 'ic14', 'ic10']
+    size_str = ["ic07", "ic08", "ic09", "ic11", "ic12", "ic13", "ic14", "ic10"]
     file_size = 0
     entries = []
     for index, s in enumerate(sizes):
         temp = io.BytesIO()
         nb = im.resize((s, s))
-        nb.save(temp, 'png')
+        nb.save(temp, "png")
         file_size += len(temp.getvalue())
-        entries.append({
-            'type': size_str[index],
-            'size': len(temp.getvalue()),
-            'stream': temp
-        })
+        entries.append(
+            {"type": size_str[index], "size": len(temp.getvalue()), "stream": temp}
+        )
 
     # Header
-    fp.write(struct.pack('i', MAGIC)[::-1])
-    fp.write(struct.pack('i', file_size)[::-1])
+    fp.write(struct.pack("i", MAGIC)[::-1])
+    fp.write(struct.pack("i", file_size)[::-1])
 
     # TOC
     toc_size = HEADER_SIZE + (len(entries) * HEADER_SIZE)
-    fp.write(struct.pack('i', to_int(TOC))[::-1])
-    fp.write(struct.pack('i', toc_size)[::-1])
+    fp.write(struct.pack("i", to_int(TOC))[::-1])
+    fp.write(struct.pack("i", toc_size)[::-1])
     for e in entries:
-        fp.write(struct.pack('i', to_int(e.get('type')))[::-1])
-        fp.write(struct.pack('i', HEADER_SIZE + e.get('size'))[::-1])
+        fp.write(struct.pack("i", to_int(e.get("type")))[::-1])
+        fp.write(struct.pack("i", HEADER_SIZE + e.get("size"))[::-1])
 
     # Data
     for index, e in enumerate(entries):
-        fp.write(struct.pack('i', to_int(e.get('type')))[::-1])
-        fp.write(struct.pack('i', HEADER_SIZE + e.get('size'))[::-1])
-        fp.write(e.get('stream').getvalue())
+        fp.write(struct.pack("i", to_int(e.get("type")))[::-1])
+        fp.write(struct.pack("i", HEADER_SIZE + e.get("size"))[::-1])
+        fp.write(e.get("stream").getvalue())
 
     fp.flush()
 

--- a/src/PIL/IcnsImagePlugin.py
+++ b/src/PIL/IcnsImagePlugin.py
@@ -325,9 +325,10 @@ def _save(im, fp, filename):
     size_str = ["ic07", "ic08", "ic09", "ic11", "ic12", "ic13", "ic14", "ic10"]
     file_size = 0
     entries = []
+    provided_images = {im.width: im for im in im.encoderinfo.get("append_images", [])}
     for index, s in enumerate(sizes):
         temp = io.BytesIO()
-        nb = im.resize((s, s))
+        nb = provided_images[s] if s in provided_images else im.resize((s, s))
         nb.save(temp, "png")
         file_size += len(temp.getvalue())
         entries.append(


### PR DESCRIPTION
Hi. Here are some suggestions to help https://github.com/python-pillow/Pillow/pull/4526

* Lint formatting fixes and removing now unused imports
* Updating the tests so that systems other than macOS are no longer skipped
* Restores the 'append_images' argument, which was removed in your PR. This removal of functionality would fail the tests